### PR TITLE
Fix order summary button enable logic

### DIFF
--- a/src/public/pages/Ordersummary.vue
+++ b/src/public/pages/Ordersummary.vue
@@ -79,7 +79,7 @@ const isButtonDisabled = computed(() => {
   return (
     !date.value ||
     !props.vehicleData ||
-    !props.vehicleData || !Array.isArray(props.vehicleData) || props.vehicleData.length === 0 || !props.vehicleData[0]?.registration ||
+    !props.vehicleData.registration ||
     // Check if selectedRepairs is empty
     props.selectedRepairs.length === 0
   );


### PR DESCRIPTION
## Summary
- fix logic that disables the confirm booking button in `Ordersummary.vue`

## Testing
- `npm run type-check` *(fails: vue-tsc not found)*
- `npm run build` *(fails: run-p not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406ccda2688321bc6edd0ee3aadebf